### PR TITLE
Fix the submodule init docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ provides a simulated micro:bit REPL in the browser.
 To build, first fetch the submodules (don't use recursive fetch):
 
     $ git submodule update --init lib/micropython-microbit-v2
-    $ git submodule update --init lib/micropython-microbit-v2/lib/micropython
+    $ (cd lib/micropython-microbit-v2 && git submodule update --init lib/micropython)
 
 Then run (from this top-level directory):
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ provides a simulated micro:bit REPL in the browser.
 To build, first fetch the submodules (don't use recursive fetch):
 
     $ git submodule update --init lib/micropython-microbit-v2
-    $ (cd lib/micropython-microbit-v2 && git submodule update --init lib/micropython)
+    $ git -C lib/micropython-microbit-v2 submodule update --init lib/micropython
 
 Then run (from this top-level directory):
 


### PR DESCRIPTION
I find you need to be inside microbit-micropython-v2 to init
micropython (with git version 2.34.1).

Otherwise the error is:
```
error: pathspec 'lib/micropython-microbit-v2/lib/micropython' did not match any file(s) known to git
```