### PR TITLE
Interpret char as unsigned char.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,7 +33,7 @@ INC += -I$(BUILD)
 
 # Compiler settings.
 CWARN += -Wall -Wpointer-arith -Wuninitialized -Wno-array-bounds
-CFLAGS += $(INC) $(CWARN) -std=c99 $(CFLAGS_MOD) $(CFLAGS_ARCH) $(COPT) $(CFLAGS_EXTRA)
+CFLAGS += $(INC) $(CWARN) -std=c99 -funsigned-char $(CFLAGS_MOD) $(CFLAGS_ARCH) $(COPT) $(CFLAGS_EXTRA)
 
 # Debugging/Optimization
 ifdef DEBUG


### PR DESCRIPTION
This seems to match the intent and is the default on on Arm.

Fixes compiler warnings and a necessary prerequisite to speech working.

It might be that we should fix this in sam but this at least allows
progress.