### PR TITLE
Fix heap leak on soft reset.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -102,6 +102,7 @@ void mp_js_main(int heap_size) {
         microbit_hal_deinit();
         gc_sweep_all();
         mp_deinit();
+        free(heap);
     }
 }
 


### PR DESCRIPTION
Previously flashing in a loop would run out of memory.