### PR TITLE
Add filesystem limit.

### DIFF
--- a/src/demo.html
+++ b/src/demo.html
@@ -197,6 +197,14 @@
               );
               break;
             }
+            case "internal_error": {
+              console.error("Simulator internal error:");
+              console.error(e.data.error);
+              break;
+            }
+            default: {
+              // Ignore unknown message
+            }
           }
         }
       });

--- a/src/jshal.h
+++ b/src/jshal.h
@@ -37,7 +37,7 @@ int mp_js_hal_filesystem_name(int idx, char *buf);
 int mp_js_hal_filesystem_size(int idx);
 void mp_js_hal_filesystem_remove(int idx);
 int mp_js_hal_filesystem_readbyte(int idx, size_t offset);
-int mp_js_hal_filesystem_write(int idx, const char *buf, size_t len);
+bool mp_js_hal_filesystem_write(int idx, const char *buf, size_t len);
 
 void mp_js_hal_panic(int code);
 void mp_js_hal_reset(void);

--- a/src/jshal.js
+++ b/src/jshal.js
@@ -56,7 +56,7 @@ mergeInto(LibraryManager.library, {
   },
 
   mp_js_hal_filesystem_name: function (idx, buf) {
-    const name = fs.name(idx);
+    const name = Module.fs.name(idx);
     if (name === undefined) {
       return -1;
     }

--- a/src/microbitfs.c
+++ b/src/microbitfs.c
@@ -209,7 +209,12 @@ STATIC mp_uint_t microbit_file_write(mp_obj_t self_in, const void *buf, mp_uint_
         *errcode = MP_EBADF;
         return MP_STREAM_ERROR;
     }
-    return mp_js_hal_filesystem_write(self->idx, buf, size);
+    bool success = mp_js_hal_filesystem_write(self->idx, buf, size);
+    if (!success) {
+        *errcode = MP_ENOSPC;
+        return MP_STREAM_ERROR;
+    }
+    return size;
 }
 
 STATIC mp_uint_t microbit_file_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {


### PR DESCRIPTION
- Limit approximately matches the device and prevents running out of memory and unrealistic expectations.
- Allow flash to exceed limit to avoid new error scenario. This would be good to revisit in future.
- Fix broken listdir due to missing Module prefix.
- Align flash and reset behaviour.

Closes https://github.com/microbit-foundation/python-editor-next/issues/950