### PR TITLE
Sandbox the iframe.

### DIFF
--- a/src/demo.html
+++ b/src/demo.html
@@ -72,6 +72,7 @@
             title="Simulator"
             frameborder="0"
             scrolling="no"
+            sandbox="allow-scripts allow-same-origin"
           ></iframe>
           <div id="sensors" class="column"></div>
         </div>


### PR DESCRIPTION
This isn't particularly effective with the demo that loads the local simulator as it's the same origin but useful for copy/paste of this code with a real deployment URL.

See https://github.com/microbit-foundation/python-editor-next/pull/959 for the Python Editor V3 equivalent which is a bit more of a meaningful scenario.