### PR TITLE
Match micro:bit MicroPython version.

### DIFF
--- a/src/mpconfigport.h
+++ b/src/mpconfigport.h
@@ -100,7 +100,7 @@
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
 #endif
 
-#define MICROBIT_RELEASE "2.0.0"
+#define MICROBIT_RELEASE "2.1.0"
 #define MICROBIT_BOARD_NAME "micro:bit"
 #define MICROPY_HW_BOARD_NAME MICROBIT_BOARD_NAME " v" MICROBIT_RELEASE
 #define MICROPY_HW_MCU_NAME "nRF52833"


### PR DESCRIPTION
Would be nice to automate but this will do for now.

The MicroPython version itself is still wrong but non-trivial to address.

Part of #74