### PR TITLE
Intercept machine.mem32 etc.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -60,6 +60,7 @@ SRC_C += \
 	microbithal_js.c \
 	main.c \
 	mphalport.c \
+	modmachine.c \
 
 SRC_C += $(addprefix $(CODAL_PORT)/, \
 	drv_display.c \

--- a/src/modmachine.c
+++ b/src/modmachine.c
@@ -1,0 +1,34 @@
+#include "py/runtime.h"
+
+// Just defines the memory access functions, otherwise we use codal_port's
+// implementation.
+
+uintptr_t machine_mem_get_read_addr(mp_obj_t addr_o, uint align) {
+    uintptr_t addr = mp_obj_get_int_truncated(addr_o);
+        if ((addr & (align - 1)) != 0) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("address %08x is not aligned to %d bytes"), addr, align);
+    }
+
+    static const uint32_t FICR = 0x10000000;
+    static const uint32_t FICR_DEVICEID_0 = FICR + 0x060;
+    static const uint32_t FICR_DEVICEID_1 = FICR + 0x064;
+
+    static uint32_t mem;
+    switch (addr) {
+        case FICR_DEVICEID_0:
+        case FICR_DEVICEID_1: {
+            // There's machine.unique_id backed by hal for this
+            // but existing code reads via FICR.
+            mem = 0;
+            break;
+        }
+        default: {
+            mp_raise_NotImplementedError(MP_ERROR_TEXT("simulator limitation: memory read"));
+        }
+    }
+    return (uintptr_t)&mem;
+}
+
+uintptr_t machine_mem_get_write_addr(mp_obj_t addr_o, uint align) {
+    mp_raise_NotImplementedError(MP_ERROR_TEXT("simulator limitation: memory write"));
+}

--- a/src/mpconfigport.h
+++ b/src/mpconfigport.h
@@ -158,4 +158,8 @@ typedef long mp_off_t;
 // Needed for MICROPY_PY_URANDOM_SEED_INIT_FUNC.
 extern uint32_t rng_generate_random_word(void);
 
+// Intercept modmachine memory access.
+#define MICROPY_MACHINE_MEM_GET_READ_ADDR machine_mem_get_read_addr
+#define MICROPY_MACHINE_MEM_GET_WRITE_ADDR machine_mem_get_write_addr
+
 #endif


### PR DESCRIPTION
Provide a minimal implementation that allows reading the device ID but otherwise raises an exception.

I'm open to adding other FICR but this is the priority to get the code on [this support article](https://support.microbit.org/support/solutions/articles/19000070728-how-to-find-the-micro-bit-serial-number) working in the simulator.

Closes #58