### PR TITLE
Fix for reset/panic overriding the user's stop

### DIFF
--- a/src/board/index.ts
+++ b/src/board/index.ts
@@ -473,7 +473,7 @@ export class Board {
    * reset() in MicroPython code throws ResetError.
    */
   async reset(): Promise<void> {
-    this.stop(StopKind.Reset);
+    return this.stop(StopKind.Reset);
   }
 
   async flash(filesystem: Record<string, Uint8Array>): Promise<void> {

--- a/src/board/index.ts
+++ b/src/board/index.ts
@@ -138,7 +138,7 @@ export class Board {
    */
   private stopKind: StopKind = StopKind.Default;
   /**
-   * Timeout for a pending start call due to StopKind.Restart.
+   * Timeout for a pending start call due to StopKind.Reset.
    */
   private pendingRestart: any;
   /**

--- a/src/board/index.ts
+++ b/src/board/index.ts
@@ -140,7 +140,7 @@ export class Board {
   /**
    * Timeout for a pending start call due to StopKind.Reset.
    */
-  private pendingRestart: any;
+  private pendingRestartTimeout: any;
   /**
    * Timeout for the next frame of the panic animation.
    */
@@ -389,8 +389,8 @@ export class Board {
     if (this.modulePromise || this.module) {
       throw new Error("Module already exists!");
     }
-    clearTimeout(this.pendingRestart);
-    this.pendingRestart = null;
+    clearTimeout(this.pendingRestartTimeout);
+    this.pendingRestartTimeout = null;
 
     this.modulePromise = this.createModule();
     const module = await this.modulePromise;
@@ -436,7 +436,7 @@ export class Board {
         break;
       }
       case StopKind.Reset: {
-        this.pendingRestart = setTimeout(() => this.start(), 0);
+        this.pendingRestartTimeout = setTimeout(() => this.start(), 0);
         break;
       }
       case StopKind.BriefStop: {
@@ -464,9 +464,9 @@ export class Board {
         this.displayStoppedState();
       }
     }
-    if (this.pendingRestart) {
-      clearTimeout(this.pendingRestart);
-      this.pendingRestart = null;
+    if (this.pendingRestartTimeout) {
+      clearTimeout(this.pendingRestartTimeout);
+      this.pendingRestartTimeout = null;
       if (!brief) {
         this.displayStoppedState();
       }

--- a/src/board/index.ts
+++ b/src/board/index.ts
@@ -460,12 +460,16 @@ export class Board {
       clearTimeout(this.panicTimeout);
       this.panicTimeout = null;
       this.display.clear();
-      this.displayStoppedState();
+      if (!brief) {
+        this.displayStoppedState();
+      }
     }
     if (this.pendingRestart) {
       clearTimeout(this.pendingRestart);
       this.pendingRestart = null;
-      this.displayStoppedState();
+      if (!brief) {
+        this.displayStoppedState();
+      }
     }
     if (this.modulePromise) {
       this.stopKind = brief ? StopKind.BriefStop : StopKind.UserStop;

--- a/src/board/index.ts
+++ b/src/board/index.ts
@@ -50,11 +50,12 @@ enum StopKind {
    */
   Panic = "panic",
   /**
-   * The user or the program requested a reset.
+   * The program requested a reset.
    */
   Reset = "reset",
   /**
-   * An internal mode where we do not display the stop state UI as we plan to immediately restart.
+   * An internal mode where we do not display the stop state UI as we plan to immediately reset.
+   * Used for user-requested flash or reset.
    */
   BriefStop = "brief",
   /**
@@ -471,10 +472,10 @@ export class Board {
 
   /**
    * An external reset.
-   * reset() in MicroPython code throws ResetError.
    */
   async reset(): Promise<void> {
-    return this.stop(StopKind.Reset);
+    await this.stop(StopKind.BriefStop);
+    return this.start();
   }
 
   async flash(filesystem: Record<string, Uint8Array>): Promise<void> {

--- a/src/board/index.ts
+++ b/src/board/index.ts
@@ -450,7 +450,6 @@ export class Board {
   }
 
   async stop(kind: StopKind = StopKind.UserStop): Promise<void> {
-    this.stopKind = kind;
     if (this.panicTimeout) {
       clearTimeout(this.panicTimeout);
       this.panicTimeout = null;
@@ -458,6 +457,8 @@ export class Board {
       this.displayStoppedState();
     }
     if (this.modulePromise) {
+      this.stopKind = kind;
+
       // Avoid this.module as we might still be creating it (async).
       const module = await this.modulePromise;
       module.requestStop();

--- a/src/board/index.ts
+++ b/src/board/index.ts
@@ -459,7 +459,7 @@ export class Board {
     this.stopKind = StopKind.Default;
   }
 
-  async stop(kind: StopKind = StopKind.UserStop): Promise<void> {
+  async stop(brief: boolean = false): Promise<void> {
     if (this.panicTimeout) {
       clearTimeout(this.panicTimeout);
       this.panicTimeout = null;
@@ -472,7 +472,7 @@ export class Board {
       this.displayStoppedState();
     }
     if (this.modulePromise) {
-      this.stopKind = kind;
+      this.stopKind = brief ? StopKind.BriefStop : StopKind.UserStop;
       // Avoid this.module as we might still be creating it (async).
       const module = await this.modulePromise;
       module.requestStop();
@@ -487,7 +487,7 @@ export class Board {
    * An external reset.
    */
   async reset(): Promise<void> {
-    await this.stop(StopKind.BriefStop);
+    await this.stop(true);
     return this.start();
   }
 
@@ -502,7 +502,7 @@ export class Board {
     };
     if (this.modulePromise) {
       // If it's running then we need to stop before flash.
-      await this.stop(StopKind.BriefStop);
+      await this.stop(true);
     }
     flashFileSystem();
     return this.start();

--- a/src/board/index.ts
+++ b/src/board/index.ts
@@ -436,9 +436,6 @@ export class Board {
         break;
       }
       case StopKind.Reset: {
-        if (this.pendingRestart) {
-          throw new Error("Unexpected state");
-        }
         this.pendingRestart = setTimeout(() => this.start(), 0);
         break;
       }

--- a/src/board/index.ts
+++ b/src/board/index.ts
@@ -426,7 +426,7 @@ export class Board {
         if (panicCode === undefined) {
           throw new Error("Must be set");
         }
-        this.displayPanic(panicCode!);
+        this.displayPanic(panicCode);
         break;
       }
       case StopKind.Reset: {
@@ -443,7 +443,7 @@ export class Board {
         break;
       }
       default: {
-        throw new Error("Unknown stop action: " + this.stopKind);
+        throw new Error("Unknown stop kind: " + this.stopKind);
       }
     }
     this.stopKind = StopKind.Default;


### PR DESCRIPTION
Switch to an enum to make the possible states easier to follow and so we can check we're in the default state before committing to a reset or panic.

Closes https://github.com/microbit-foundation/micropython-microbit-v2-simulator/issues/86