### PR TITLE
Build debug information alongside non-debug builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 dist: build
 	mkdir -p $(BUILD)/build
 	cp -r $(SRC)/*.html $(SRC)/term.js src/examples $(BUILD)
-	cp $(SRC)/build/firmware.js $(SRC)/build/simulator.js $(SRC)/build/firmware.wasm  $(BUILD)/build/
+	cp $(SRC)/build/firmware.js $(SRC)/build/simulator.js $(SRC)/build/*.wasm  $(BUILD)/build/
 
 watch: dist
 	fswatch -o -e src/build src  | while read _; do $(MAKE) dist; done

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,6 +41,7 @@ COPT += -O3
 CFLAGS += -g
 else
 COPT += -O3 -DNDEBUG
+CFLAGS += -gseparate-dwarf
 endif
 
 JSFLAGS += -s ASYNCIFY
@@ -52,6 +53,8 @@ JSFLAGS += -s EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']" --js-library jshal.j
 
 ifdef DEBUG
 JSFLAGS += -g
+else
+JSFLAGS += -gseparate-dwarf
 endif
 
 SRC_C += \
@@ -144,7 +147,7 @@ $(BUILD)/micropython.js: $(OBJ) jshal.js simulator-js
 	$(Q)emcc $(LDFLAGS) -o $(BUILD)/firmware.js $(OBJ) $(JSFLAGS)
 
 simulator-js:
-	npx esbuild ./simulator.ts --bundle --outfile=$(BUILD)/simulator.js --loader:.svg=text
+	npx esbuild ./simulator.ts --sourcemap --minify --bundle --outfile=$(BUILD)/simulator.js --loader:.svg=text --target=es2020
 
 include $(TOP)/py/mkrules.mk
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,7 +41,7 @@ COPT += -O3
 CFLAGS += -g
 else
 COPT += -O3 -DNDEBUG
-CFLAGS += -gseparate-dwarf
+CFLAGS += -gsource-map --source-map-base=./
 endif
 
 JSFLAGS += -s ASYNCIFY
@@ -54,7 +54,7 @@ JSFLAGS += -s EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']" --js-library jshal.j
 ifdef DEBUG
 JSFLAGS += -g
 else
-JSFLAGS += -gseparate-dwarf
+JSFLAGS += -gsource-map --source-map-base=./
 endif
 
 SRC_C += \


### PR DESCRIPTION
We should then be able to use it in Chrome's Wasm/DWARF debug tooling to understand production issues.