### PR TITLE
Increase asyncify stack size

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -44,6 +44,8 @@ COPT += -O3 -DNDEBUG
 endif
 
 JSFLAGS += -s ASYNCIFY
+# We can hit lower values due to user stack use. See stack_size.py example.
+JSFLAGS += -s ASYNCIFY_STACK_SIZE=262144
 JSFLAGS += -s EXIT_RUNTIME
 JSFLAGS += -s MODULARIZE=1
 JSFLAGS += -s EXPORT_NAME=createModule

--- a/src/demo.html
+++ b/src/demo.html
@@ -100,6 +100,7 @@
               </option>
               <option value="sound_effects_user">Sound effects (user)</option>
               <option value="speech">Speech</option>
+              <option value="stack_size">Stack size</option>
               <option value="volume">Volume</option>
             </select>
             <textarea

--- a/src/examples/stack_size.py
+++ b/src/examples/stack_size.py
@@ -1,0 +1,10 @@
+def g():
+    global depth
+    depth += 1
+    g()
+depth = 0
+try:
+    g()
+except RuntimeError:
+    pass
+print('maximum recursion depth g():', depth)


### PR DESCRIPTION
This fixes the example on #105.

I've added the debug script that I used, which I aspire to turn into an automated test in future.

The value does seem rather large but not really significant in a browser context. I've not explored whether it's possible to optimise our asyncify use. 

I found an analogous issue in a JS interpreter here: https://github.com/justjake/quickjs-emscripten/issues/112